### PR TITLE
Fix positive lookahead matching explanation

### DIFF
--- a/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/lookahead_assertion/index.md
@@ -39,9 +39,9 @@ Unlike other regular expression operators, there's no backtracking into a lookah
 The matching of the pattern above happens as follows:
 
 1. The lookahead `(a+)` succeeds before the first `"a"` in `"baabac"`, and `"aa"` is captured because the quantifier is greedy.
-2. `a*b` matches the `"b"` in `"baabac"`.
+2. `a*b` matches the `"aab"` in `"baabac"` because lookaheads don't consume the captured `"aa"`.
 3. `\1` does not match the following string, because that requires 2 `"a"`s, but only 1 is available. So the matcher backtracks, but it doesn't go into the lookahead, so the capturing group cannot be reduced to 1 `"a"`, and the entire match fails at this point.
-4. `exec()` re-attempts matching at the next position — before the second `"a"`. This time, the lookahead matches `"a"`, and `a*b` matches `"b"`. The backreference `\1` matches the captured `"a"`, and the match succeeds.
+4. `exec()` re-attempts matching at the next position — before the second `"a"`. This time, the lookahead matches `"a"`, and `a*b` matches `"ab"`. The backreference `\1` matches the captured `"a"`, and the match succeeds.
 
 If the regex is able to backtrack into the lookahead and revise the choice made in there, then the match would succeed at step 3 by `(a+)` matching the first `"a"` (instead of the first two `"a"`s) and `a*b` matching `"ab"`, without even re-attempting the next input position.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
On https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion, the strings that `a*b` captures are incorrect.

I put a capturing group around `"a*b"` to check this: 
```js
/(?=(a+))(a*b)\1/.exec("baabac"); // ['aba', 'a', 'ab']
``` 

### Motivation

They help readers better understand that lookaheads don't consume the string they match.
